### PR TITLE
Add OpenTelemetry plugin transport for OTLP log export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ntlogger",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ntlogger",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@sentry/node": "^10.34.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ntlogger",
-  "version": "2.10.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ntlogger",
-      "version": "2.10.0",
+      "version": "2.9.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@sentry/node": "^10.34.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ntlogger",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ntlogger",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@sentry/node": "^10.34.0",
@@ -24,9 +24,33 @@
         "split2": "^4.2.0"
       },
       "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0",
+        "@opentelemetry/api-logs": ">=0.50.0",
+        "@opentelemetry/exporter-logs-otlp-http": ">=0.50.0",
+        "@opentelemetry/resources": ">=1.20.0",
+        "@opentelemetry/sdk-logs": ">=0.50.0",
+        "@opentelemetry/semantic-conventions": ">=1.20.0",
         "pino": ">=8.0.0"
       },
       "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/api-logs": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-logs-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-logs": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        },
         "pino": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ntlogger",
-  "version": "2.10.0",
+  "version": "2.9.1",
   "description": "A Custom Ready-To-Go Logging Wrapper Built on Winston",
   "keywords": [
     "custom logger",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ntlogger",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "A Custom Ready-To-Go Logging Wrapper Built on Winston",
   "keywords": [
     "custom logger",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "logging",
     "logging utility",
     "mysql compatible",
+    "opentelemetry",
+    "otel",
+    "otlp",
     "pino transport",
     "sentry compatible",
     "syslog compatible",
@@ -52,10 +55,34 @@
     "split2": "^4.2.0"
   },
   "peerDependencies": {
-    "pino": ">=8.0.0"
+    "pino": ">=8.0.0",
+    "@opentelemetry/api": ">=1.9.0",
+    "@opentelemetry/api-logs": ">=0.50.0",
+    "@opentelemetry/sdk-logs": ">=0.50.0",
+    "@opentelemetry/exporter-logs-otlp-http": ">=0.50.0",
+    "@opentelemetry/resources": ">=1.20.0",
+    "@opentelemetry/semantic-conventions": ">=1.20.0"
   },
   "peerDependenciesMeta": {
     "pino": {
+      "optional": true
+    },
+    "@opentelemetry/api": {
+      "optional": true
+    },
+    "@opentelemetry/api-logs": {
+      "optional": true
+    },
+    "@opentelemetry/sdk-logs": {
+      "optional": true
+    },
+    "@opentelemetry/exporter-logs-otlp-http": {
+      "optional": true
+    },
+    "@opentelemetry/resources": {
+      "optional": true
+    },
+    "@opentelemetry/semantic-conventions": {
       "optional": true
     }
   },

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -13,6 +13,7 @@ const plugins = {
     Discord     : require('./discord'),
     Teams       : require('./teams'),
     OpenObserve : require('./openobserve'),
+    OpenTelemetry : require('./otel'),
 
     // WIP SMSMail : require('./smsMail'),
 };

--- a/plugins/otel.js
+++ b/plugins/otel.js
@@ -1,0 +1,265 @@
+/**
+ * @file /plugins/otel.js
+ * @description Sends logs to an OpenTelemetry collector via the OTLP Logs SDK.
+ *
+ * OpenTelemetry packages are optional peer dependencies. Install them when using this plugin:
+ *   npm install @opentelemetry/api @opentelemetry/api-logs @opentelemetry/sdk-logs \
+ *               @opentelemetry/exporter-logs-otlp-http @opentelemetry/resources \
+ *               @opentelemetry/semantic-conventions
+ *
+ * For gRPC or protobuf transport, install the corresponding exporter package and
+ * pass it via the `exporter` option.
+ */
+
+const Transport = require('winston-transport');
+const levels = require('../lib/levels');
+
+const ANSI_REGEX = /\[[0-9;]*m/g;
+
+function stripAnsi(str) {
+    if (typeof str !== 'string') return str;
+    return str.replace(ANSI_REGEX, '');
+}
+
+/**
+ * Map ntlogger levels to OpenTelemetry SeverityNumber values.
+ * See: https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
+ */
+const SEVERITY_NUMBER = {
+    internal: 1,  // TRACE
+    trace:    1,  // TRACE
+    debug:    5,  // DEBUG
+    info:     9,  // INFO
+    warn:     13, // WARN
+    error:    17, // ERROR
+    fatal:    21, // FATAL
+};
+
+const SEVERITY_TEXT = {
+    internal: 'TRACE',
+    trace:    'TRACE',
+    debug:    'DEBUG',
+    info:     'INFO',
+    warn:     'WARN',
+    error:    'ERROR',
+    fatal:    'FATAL',
+};
+
+/**
+ * Lazily require an OTel package, returning null if it's not installed.
+ * Lets the plugin loader skip OTel gracefully when deps are missing.
+ */
+function tryRequire(name) {
+    try {
+        return require(name);
+    } catch (err) {
+        if (err && err.code === 'MODULE_NOT_FOUND') return null;
+        throw err;
+    }
+}
+
+class OpenTelemetryTransport extends Transport {
+    constructor(opts = {}) {
+        super(opts);
+
+        this.name = 'OpenTelemetry Transport for NTLogger';
+
+        // Level threshold (default: log everything down to 'trace')
+        this.level = opts.level || 'trace';
+        if (!(this.level in levels)) {
+            throw new Error(`Invalid log level: ${this.level}`);
+        }
+        this.levelPriority = levels[this.level];
+
+        this.includeTraceContext = opts.includeTraceContext !== false;
+        this.stripAnsi = opts.stripAnsi !== false;
+
+        // Caller-supplied LoggerProvider takes precedence and lets the plugin
+        // run without the OTel SDK packages installed (useful for tests).
+        if (opts.loggerProvider) {
+            this.loggerProvider = opts.loggerProvider;
+            this._ownsProvider = false;
+        } else {
+            const sdkLogs = tryRequire('@opentelemetry/sdk-logs');
+            if (!sdkLogs) {
+                throw new Error(
+                    'OpenTelemetry plugin requires @opentelemetry/sdk-logs (and an exporter) ' +
+                    'when no `loggerProvider` is supplied. ' +
+                    'Install with: npm install @opentelemetry/sdk-logs @opentelemetry/api-logs @opentelemetry/exporter-logs-otlp-http'
+                );
+            }
+            this.loggerProvider = this._buildLoggerProvider(opts, sdkLogs);
+            this._ownsProvider = true;
+        }
+
+        const instrumentationName = opts.instrumentationName || 'ntlogger';
+        const instrumentationVersion = opts.instrumentationVersion || undefined;
+        this.otelLogger = this.loggerProvider.getLogger(instrumentationName, instrumentationVersion);
+
+        // Optional @opentelemetry/api for trace context correlation
+        if (this.includeTraceContext) {
+            const api = tryRequire('@opentelemetry/api');
+            this._traceApi = api && api.trace ? api.trace : null;
+        }
+    }
+
+    /**
+     * Build a LoggerProvider from configuration when one isn't supplied.
+     */
+    _buildLoggerProvider(opts, sdkLogs) {
+        const { LoggerProvider, BatchLogRecordProcessor, SimpleLogRecordProcessor } = sdkLogs;
+
+        let exporter = opts.exporter;
+        if (!exporter) {
+            const otlpHttp = tryRequire('@opentelemetry/exporter-logs-otlp-http');
+            if (!otlpHttp) {
+                throw new Error(
+                    'OpenTelemetry plugin requires either an `exporter` instance or ' +
+                    '@opentelemetry/exporter-logs-otlp-http installed. ' +
+                    'Install with: npm install @opentelemetry/exporter-logs-otlp-http'
+                );
+            }
+            exporter = new otlpHttp.OTLPLogExporter({
+                url: opts.url,
+                headers: opts.headers,
+                concurrencyLimit: opts.concurrencyLimit,
+                timeoutMillis: opts.timeoutMillis,
+            });
+        }
+
+        const Processor = opts.useSimpleProcessor ? SimpleLogRecordProcessor : BatchLogRecordProcessor;
+        const processor = new Processor(exporter, opts.processorOptions || {});
+
+        let resource;
+        const resources = tryRequire('@opentelemetry/resources');
+        if (resources && (opts.resource || opts.resourceAttributes || opts.serviceName)) {
+            if (opts.resource) {
+                resource = opts.resource;
+            } else {
+                const attrs = { ...(opts.resourceAttributes || {}) };
+                if (opts.serviceName) {
+                    const semconv = tryRequire('@opentelemetry/semantic-conventions');
+                    const key = (semconv && semconv.ATTR_SERVICE_NAME) || 'service.name';
+                    attrs[key] = opts.serviceName;
+                    if (opts.serviceVersion) {
+                        const vkey = (semconv && semconv.ATTR_SERVICE_VERSION) || 'service.version';
+                        attrs[vkey] = opts.serviceVersion;
+                    }
+                }
+                resource = resources.resourceFromAttributes
+                    ? resources.resourceFromAttributes(attrs)
+                    : new resources.Resource(attrs);
+            }
+        }
+
+        return new LoggerProvider({
+            resource,
+            processors: [processor],
+        });
+    }
+
+    /**
+     * Flatten metadata into OTel-compatible primitive/array attributes.
+     * Objects are JSON-stringified since OTel attributes can't be nested.
+     */
+    _toAttributes(meta) {
+        const attrs = {};
+        for (const [key, value] of Object.entries(meta)) {
+            if (value === null || value === undefined) continue;
+            if (key === 'timestamp' || key === 'timeCreated') continue;
+
+            const t = typeof value;
+            if (t === 'string') {
+                attrs[key] = this.stripAnsi ? stripAnsi(value) : value;
+            } else if (t === 'number' || t === 'boolean') {
+                attrs[key] = value;
+            } else if (Array.isArray(value)) {
+                attrs[key] = value.map(v =>
+                    typeof v === 'object' && v !== null ? JSON.stringify(v) : v
+                );
+            } else if (t === 'object') {
+                try {
+                    attrs[key] = JSON.stringify(value);
+                } catch {
+                    attrs[key] = String(value);
+                }
+            } else {
+                attrs[key] = String(value);
+            }
+        }
+        return attrs;
+    }
+
+    log(info, callback) {
+        setImmediate(() => {
+            this.emit('logged', info);
+        });
+
+        const { level, message, ...meta } = info;
+
+        if (levels[level] === undefined || levels[level] > this.levelPriority) {
+            callback();
+            return;
+        }
+
+        const severityNumber = SEVERITY_NUMBER[level] ?? SEVERITY_NUMBER.info;
+        const severityText = SEVERITY_TEXT[level] || String(level).toUpperCase();
+        const body = this.stripAnsi && typeof message === 'string' ? stripAnsi(message) : message;
+
+        const record = {
+            severityNumber,
+            severityText,
+            body,
+            attributes: this._toAttributes(meta),
+        };
+
+        if (this._traceApi) {
+            const span = this._traceApi.getActiveSpan();
+            const ctx = span && span.spanContext && span.spanContext();
+            if (ctx && ctx.traceId && ctx.spanId) {
+                record.traceId = ctx.traceId;
+                record.spanId = ctx.spanId;
+                if (typeof ctx.traceFlags === 'number') {
+                    record.traceFlags = ctx.traceFlags;
+                }
+            }
+        }
+
+        try {
+            this.otelLogger.emit(record);
+        } catch (err) {
+            console.error(`OpenTelemetry transport emit failed: ${err.message}`);
+        }
+
+        callback();
+    }
+
+    /**
+     * Force-flush pending log records.
+     */
+    flush() {
+        if (this.loggerProvider && typeof this.loggerProvider.forceFlush === 'function') {
+            return this.loggerProvider.forceFlush();
+        }
+        return Promise.resolve();
+    }
+
+    /**
+     * Shut down the LoggerProvider (only if this transport created it).
+     */
+    async close() {
+        if (this._ownsProvider && this.loggerProvider && typeof this.loggerProvider.shutdown === 'function') {
+            try {
+                await this.loggerProvider.shutdown();
+            } catch (err) {
+                console.error(`OpenTelemetry transport shutdown failed: ${err.message}`);
+            }
+        }
+    }
+}
+
+module.exports = {
+    transport: OpenTelemetryTransport,
+    SEVERITY_NUMBER,
+    SEVERITY_TEXT,
+};

--- a/tests/otel-plugin.test.js
+++ b/tests/otel-plugin.test.js
@@ -1,0 +1,266 @@
+/**
+ * @file /tests/otel-plugin.test.js
+ * @description Tests for the OpenTelemetry plugin transport.
+ *
+ * These tests inject a mock LoggerProvider so the OTel SDK packages don't need
+ * to be installed to verify the transport's behavior.
+ */
+
+const { transport: OpenTelemetryTransport, SEVERITY_NUMBER, SEVERITY_TEXT } = require('../plugins/otel');
+
+/**
+ * Build a mock LoggerProvider/Logger that captures emitted records.
+ */
+function makeMockProvider() {
+    const emitted = [];
+    const flushCalls = [];
+    const shutdownCalls = [];
+
+    const otelLogger = {
+        emit: (record) => emitted.push(record),
+    };
+
+    const provider = {
+        getLogger: jest.fn().mockReturnValue(otelLogger),
+        forceFlush: jest.fn(() => {
+            flushCalls.push(Date.now());
+            return Promise.resolve();
+        }),
+        shutdown: jest.fn(() => {
+            shutdownCalls.push(Date.now());
+            return Promise.resolve();
+        }),
+    };
+
+    return { provider, emitted, flushCalls, shutdownCalls };
+}
+
+describe('OpenTelemetry plugin transport', () => {
+    test('SEVERITY_NUMBER maps ntlogger levels to OTel severity numbers', () => {
+        expect(SEVERITY_NUMBER.trace).toBe(1);
+        expect(SEVERITY_NUMBER.internal).toBe(1);
+        expect(SEVERITY_NUMBER.debug).toBe(5);
+        expect(SEVERITY_NUMBER.info).toBe(9);
+        expect(SEVERITY_NUMBER.warn).toBe(13);
+        expect(SEVERITY_NUMBER.error).toBe(17);
+        expect(SEVERITY_NUMBER.fatal).toBe(21);
+    });
+
+    test('SEVERITY_TEXT maps ntlogger levels to uppercase severity text', () => {
+        expect(SEVERITY_TEXT.info).toBe('INFO');
+        expect(SEVERITY_TEXT.error).toBe('ERROR');
+        expect(SEVERITY_TEXT.fatal).toBe('FATAL');
+    });
+
+    test('emits a log record with body, severityNumber, and severityText', (done) => {
+        const { provider, emitted } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider });
+
+        t.log({ level: 'info', message: 'hello world', userId: 42 }, () => {
+            expect(emitted).toHaveLength(1);
+            expect(emitted[0]).toMatchObject({
+                severityNumber: 9,
+                severityText: 'INFO',
+                body: 'hello world',
+                attributes: { userId: 42 },
+            });
+            done();
+        });
+    });
+
+    test('respects level threshold and drops below-threshold records', (done) => {
+        const { provider, emitted } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider, level: 'warn' });
+
+        t.log({ level: 'debug', message: 'noisy' }, () => {
+            t.log({ level: 'info', message: 'also noisy' }, () => {
+                t.log({ level: 'warn', message: 'kept' }, () => {
+                    t.log({ level: 'error', message: 'kept too' }, () => {
+                        expect(emitted).toHaveLength(2);
+                        expect(emitted.map(r => r.body)).toEqual(['kept', 'kept too']);
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    test('strips ANSI escape codes from string body and attributes by default', (done) => {
+        const { provider, emitted } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider });
+
+        const colored = '[31mred message[0m';
+        t.log({ level: 'info', message: colored, label: '[32mgreen[0m', count: 5 }, () => {
+            expect(emitted[0].body).toBe('red message');
+            expect(emitted[0].attributes.label).toBe('green');
+            expect(emitted[0].attributes.count).toBe(5);
+            done();
+        });
+    });
+
+    test('preserves ANSI codes when stripAnsi is disabled', (done) => {
+        const { provider, emitted } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider, stripAnsi: false });
+
+        const colored = '[31mred message[0m';
+        t.log({ level: 'info', message: colored }, () => {
+            expect(emitted[0].body).toBe(colored);
+            done();
+        });
+    });
+
+    test('drops timestamp/timeCreated and serializes nested objects as JSON', (done) => {
+        const { provider, emitted } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider });
+
+        t.log({
+            level: 'info',
+            message: 'test',
+            timestamp: '2026-01-01T00:00:00Z',
+            timeCreated: 123,
+            nested: { a: 1, b: 'x' },
+            list: [1, 'two', { three: 3 }],
+            flag: true,
+        }, () => {
+            const attrs = emitted[0].attributes;
+            expect(attrs.timestamp).toBeUndefined();
+            expect(attrs.timeCreated).toBeUndefined();
+            expect(attrs.nested).toBe('{"a":1,"b":"x"}');
+            expect(attrs.list).toEqual([1, 'two', '{"three":3}']);
+            expect(attrs.flag).toBe(true);
+            done();
+        });
+    });
+
+    test('skips null and undefined metadata values', (done) => {
+        const { provider, emitted } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider });
+
+        t.log({ level: 'info', message: 'test', empty: null, missing: undefined, kept: 'yes' }, () => {
+            const attrs = emitted[0].attributes;
+            expect(attrs.empty).toBeUndefined();
+            expect(attrs.missing).toBeUndefined();
+            expect(attrs.kept).toBe('yes');
+            done();
+        });
+    });
+
+    test('passes instrumentationName and version to getLogger', () => {
+        const { provider } = makeMockProvider();
+        new OpenTelemetryTransport({
+            loggerProvider: provider,
+            instrumentationName: 'my-app-logger',
+            instrumentationVersion: '2.3.4',
+        });
+        expect(provider.getLogger).toHaveBeenCalledWith('my-app-logger', '2.3.4');
+    });
+
+    test('defaults instrumentation name to "ntlogger"', () => {
+        const { provider } = makeMockProvider();
+        new OpenTelemetryTransport({ loggerProvider: provider });
+        expect(provider.getLogger).toHaveBeenCalledWith('ntlogger', undefined);
+    });
+
+    test('flush() proxies to loggerProvider.forceFlush', async () => {
+        const { provider } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider });
+        await t.flush();
+        expect(provider.forceFlush).toHaveBeenCalledTimes(1);
+    });
+
+    test('close() does NOT shut down an externally-supplied loggerProvider', async () => {
+        const { provider } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider });
+        await t.close();
+        expect(provider.shutdown).not.toHaveBeenCalled();
+    });
+
+    test('throws on invalid log level', () => {
+        const { provider } = makeMockProvider();
+        expect(() => new OpenTelemetryTransport({ loggerProvider: provider, level: 'verbose' }))
+            .toThrow(/Invalid log level/);
+    });
+
+    test('drops records with unknown level', (done) => {
+        const { provider, emitted } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider });
+
+        t.log({ level: 'verbose', message: 'should drop' }, () => {
+            expect(emitted).toHaveLength(0);
+            done();
+        });
+    });
+});
+
+describe('OpenTelemetry plugin transport — trace correlation', () => {
+    test('attaches traceId/spanId from active span when @opentelemetry/api is available', (done) => {
+        const { provider, emitted } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider });
+
+        // Mock the trace API by injecting it directly on the instance.
+        t._traceApi = {
+            getActiveSpan: () => ({
+                spanContext: () => ({
+                    traceId: 'abc123',
+                    spanId: 'def456',
+                    traceFlags: 1,
+                }),
+            }),
+        };
+
+        t.log({ level: 'info', message: 'with trace' }, () => {
+            expect(emitted[0].traceId).toBe('abc123');
+            expect(emitted[0].spanId).toBe('def456');
+            expect(emitted[0].traceFlags).toBe(1);
+            done();
+        });
+    });
+
+    test('omits trace fields when no active span', (done) => {
+        const { provider, emitted } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider });
+
+        t._traceApi = { getActiveSpan: () => undefined };
+
+        t.log({ level: 'info', message: 'no trace' }, () => {
+            expect(emitted[0].traceId).toBeUndefined();
+            expect(emitted[0].spanId).toBeUndefined();
+            done();
+        });
+    });
+
+    test('does not attach trace context when includeTraceContext is false', (done) => {
+        const { provider, emitted } = makeMockProvider();
+        const t = new OpenTelemetryTransport({ loggerProvider: provider, includeTraceContext: false });
+
+        expect(t._traceApi).toBeUndefined();
+
+        t.log({ level: 'info', message: 'no correlation' }, () => {
+            expect(emitted[0].traceId).toBeUndefined();
+            done();
+        });
+    });
+});
+
+describe('OpenTelemetry plugin — registered with plugin loader', () => {
+    test('OpenTelemetry is exported from plugins/index', () => {
+        const { initPlugins } = require('../plugins/index');
+        // Initializing with disabled OTel plugin should not throw and should return empty array.
+        const transports = initPlugins([
+            { name: 'OpenTelemetry', enabled: false, config: {} },
+        ]);
+        expect(transports).toEqual([]);
+    });
+
+    test('initPlugins creates an OpenTelemetry transport when given a mock loggerProvider', () => {
+        const { initPlugins } = require('../plugins/index');
+        const { provider } = makeMockProvider();
+
+        const transports = initPlugins([
+            { name: 'OpenTelemetry', enabled: true, config: { loggerProvider: provider } },
+        ]);
+
+        expect(transports).toHaveLength(1);
+        expect(transports[0].name).toBe('OpenTelemetry Transport for NTLogger');
+    });
+});


### PR DESCRIPTION
## Summary

Adds a new OpenTelemetry plugin transport that sends logs to an OpenTelemetry collector via the OTLP Logs SDK. The transport integrates with ntlogger's plugin architecture and supports optional trace context correlation when the `@opentelemetry/api` package is available.

## Key Changes

- **New plugin:** `plugins/otel.js` — `OpenTelemetryTransport` class extending `winston-transport`
  - Maps ntlogger's 7 custom log levels to OpenTelemetry severity numbers and text
  - Flattens metadata into OTel-compatible primitive/array attributes (objects JSON-stringified)
  - Strips ANSI escape codes by default (configurable via `stripAnsi` option)
  - Filters records by level threshold (respects `level` option)
  - Optionally attaches trace context (traceId, spanId, traceFlags) from active span when `@opentelemetry/api` is available
  - Supports both caller-supplied `LoggerProvider` (for testing) and auto-initialization from OTel SDK packages
  - Implements `flush()` (proxies to `loggerProvider.forceFlush()`) and `close()` (shuts down provider only if transport created it)

- **Plugin registration:** Updated `plugins/index.js` to register the OpenTelemetry transport in the plugin loader

- **Package metadata:** Updated `package.json`
  - Added OpenTelemetry keywords (`opentelemetry`, `otel`, `otlp`)
  - Declared OTel packages as optional peer dependencies with `peerDependenciesMeta`

- **Comprehensive test suite:** `tests/otel-plugin.test.js` (266 lines)
  - Tests severity mapping, log record emission, level filtering, ANSI stripping
  - Tests metadata handling (null/undefined skipping, nested object serialization, timestamp/timeCreated dropping)
  - Tests trace context correlation (active span attachment, omission when no span, opt-out via `includeTraceContext: false`)
  - Tests instrumentation name/version configuration
  - Tests flush/close lifecycle methods
  - Tests plugin loader integration
  - Uses mock `LoggerProvider` to avoid requiring OTel SDK packages for test execution

## Implementation Details

- **Graceful degradation:** Uses `tryRequire()` helper to load OTel packages only when needed; plugin fails with clear error message if dependencies are missing and no `loggerProvider` is supplied
- **Lazy trace API loading:** Only loads `@opentelemetry/api` if `includeTraceContext` is true (default)
- **Resource support:** Auto-builds `Resource` from `serviceName`, `serviceVersion`, and `resourceAttributes` options when `@opentelemetry/resources` is available
- **Processor flexibility:** Supports both `BatchLogRecordProcessor` (default) and `SimpleLogRecordProcessor` via `useSimpleProcessor` option
- **Error resilience:** Catches and logs errors during record emission and provider shutdown without crashing the logger

https://claude.ai/code/session_011mPy8kYFAx3U17NBmxTRe8