### PR TITLE
chore: bump version to 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ntlogger",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ntlogger",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@sentry/node": "^10.48.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ntlogger",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "A Custom Ready-To-Go Logging Wrapper Built on Winston",
   "keywords": [
     "custom logger",


### PR DESCRIPTION
## Summary

Bumps version `2.9.1` → `2.10.0` to cut a new release.

Once merged, I'll tag `v2.10.0` on `main` to trigger the CI npm publish workflow.

## Changes since v2.9.1

- feat: OpenTelemetry plugin transport for OTLP log export (#20)
- docs: clarify pino optional deps and document hidden logger behaviors (#21)
- chore(deps): bump production and development dependencies (#22)
- test: comprehensive test coverage for core logger and plugin subsystems (#23)

Minor bump because of the new OpenTelemetry plugin feature.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, tag `v2.10.0` pushed to `main`
- [ ] GitHub Actions publishes `ntlogger@2.10.0` to npm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rr28GDviucqQEpsq4eJC4Z)_